### PR TITLE
Fix the option tab title

### DIFF
--- a/_locales/it/messages.json
+++ b/_locales/it/messages.json
@@ -103,7 +103,7 @@
         "message": "ritardo in millisecondi dopo l'abilitazione di ogni estensione"
     },
     "context_options": {
-        "message": "Contesto - Opzioni"
+        "message": "Context - Opzioni"
     },
     "remove_context": {
         "message": "Rimuovere contesto?"


### PR DESCRIPTION
I didn't see to have translated also the extension name into the Options page title. So I restored the original name.
