### PR TITLE
Adjust to more appropriate term for the button of the dialog.

### DIFF
--- a/js/options/dialogs.js
+++ b/js/options/dialogs.js
@@ -64,7 +64,7 @@ function openEditContextDialog(context) {
 	$( '#new-context-form' ).find('#showExtensionIcon').prop('checked', (contextIcon === 'show_extension'));
 
 	var buttons = {};
-	buttons[chrome.i18n.getMessage("edit")] = function() {
+	buttons[chrome.i18n.getMessage("save")] = function() {
 				clearDialogErrors($(this));
 				$(this).find('input, ul').removeClass("ui-state-error");
 


### PR DESCRIPTION
The appropriate verb to be used in the form to edit context is "Save" rather than "Edit".
